### PR TITLE
Make adapters extensible and overridable

### DIFF
--- a/adapters/adapter.coffee
+++ b/adapters/adapter.coffee
@@ -3,9 +3,12 @@ class Adapter
     constructor: (@adapters) ->
         @disabled = []
         for ext, adapter of @adapters
-            do (ext) =>
-                Object.defineProperty @, ext,
-                    get: -> @adapters[ext] if ext not in @disabled
+            @install ext, adapter
+
+    install: (ext, adapter) ->
+        Object.defineProperty @, ext,
+            configurable: yes
+            get: -> adapter if ext not in @disabled
 
     disable: (ext) ->
         if not ext then @disabled.push ext for ext of @adapters

--- a/flour.coffee
+++ b/flour.coffee
@@ -70,7 +70,7 @@ flour =
         done = ->
             return unless files.length is ++counter
             # Use destination or first file to find out output extension
-            shim = new File(dest || files[0])
+            shim = new File(dest || files[0], flour)
             shim.ext = shim.targetExtension()
             sep = separators[shim.ext] ? "\n"
             shim.buffer = [options.before] + results.join(sep) + [options.after]
@@ -78,7 +78,7 @@ flour =
                 success dest, @, output, null, 'Packaged', cb
 
         files.forEach (file, i) ->
-            file = new File file
+            file = new File file, flour
             file.compile (output) ->
                 results[i] = [options.wrap[0]] + output + [options.wrap[1]]
                 done()
@@ -113,11 +113,11 @@ flour =
                 results = []
                 count = files.length
                 files.forEach (f, i) ->
-                    new File(f).read (output) ->
+                    new File(f, flour).read (output) ->
                         results[i] = results[f] = output
                         if --count is 0 then cb results, files
 
-        new File(filepath).read cb
+        new File(filepath, flour).read cb
 
     # Load adapters
     minifiers : require './adapters/minifiers'
@@ -209,13 +209,13 @@ success = (dest, file, output, sourceMap, action, cb) ->
 
             for file, i in files
                 rest[rest.length-1] = proxy_cb i if proxy_cb
-                dm.bind(original).apply flour, [new File file].concat(rest)
+                dm.bind(original).apply flour, [new File(file, flour)].concat(rest)
 
             return
 
         # Create a File object with the given path. If it turns out
         # to be a wildcard path, we just discard it.
-        file = new File files
+        file = new File files, flour
 
         # Handle wildcard paths.
         if isWild file.base

--- a/lib/file.coffee
+++ b/lib/file.coffee
@@ -9,13 +9,9 @@ logger = require './logger'
 
 passthrough = (file, args..., cb) -> file.read cb
 
-minifiers = require '../adapters/minifiers'
-compilers = require '../adapters/compilers'
-linters   = require '../adapters/linters'
-
 class File
 
-    constructor: (file, @buffer) ->
+    constructor: (file, @context, @buffer) ->
         @path = file
         @ext  = path.extname(file).replace /^\./, ''
         @name = path.basename file
@@ -36,19 +32,19 @@ class File
 
     compile: (cb) ->
         @action = 'compiling'
-        compiler = compilers[@ext] or passthrough
+        compiler = @context.compilers[@ext] or passthrough
         @domain.run =>
             compiler.call compiler, @, cb.bind(@)
 
     minify: (cb) ->
         @action = 'minifying'
-        minifier = minifiers[@ext] or passthrough
+        minifier = @context.minifiers[@ext] or passthrough
         @domain.run =>
             minifier.call minifier, @, cb.bind(@)
 
     lint: (cb) ->
         @action = 'linting'
-        linter = linters[@ext] or passthrough
+        linter = @context.linters[@ext] or passthrough
         @domain.run =>
             linter.call linter, @, cb.bind(@)
 


### PR DESCRIPTION
The off-the-shelf implementation of the Stylus compiler is not sufficient for my needs (I need to define `stylus.url()` before rendering CSS). That is why I was overriding `flour.compilers.styl` by simply assigning a new function inside my `Cakefile`.

Today I upgraded Flour and I noticed that some changes were done to the software which made it suddenly impossible (as far as I can see) to override a compiler or even simply add one. The cause is a combination of the following factors:
- All compiling (et al.) takes place in `lib/file`, which in turn fetches its compilers from `adapters/compilers`. This dependency is hard-coded, so no opportunity to adjust the set of compilers from the default implementation.
- All the while, the set of compilers is still publicly available from `flour.compilers` (which is initialized from `adapters/compilers` as well!) -- to me it's pretty obvious that this should be the central collection from which compilers should always be obtained, as that would allow us to mess with them before the fact.
- Lastly, the implementation of `adapters/adapter` blocks extensibility as well. It only accepts new adapters from its constructor, which basically means that as soon as an adapter has been instantiated it is set in stone forever. Not even a compiler can be _added_!

In the corresponding pull request I addressed all these issues so to re-enable monkey-patching in the `Cakefile`. To illustrate, this is what I am doing:

```
flour = require 'flour'

# Overwrite default `styl` compiler because we need a custom version:
# * We want to be able to explicitly decide in our style sheet whether we want
#   to compile a file as data URL or not.
# * We always want to import `nib`.
flour.compilers.install 'styl', (file, cb) ->
    stylus = require 'stylus'
    nib = require 'nib'

    options =
        filename: file.name
        paths: [file.dir]
        compress: @compress ? yes

    file.read (code) ->
        renderer = stylus code, options
        renderer.define 'inline-url', stylus.url()
        renderer.use nib()
        renderer.import 'nib'
        renderer.render (err, css) ->
            throw err if err
            cb css
```

Note that the thing lacking in my suggested solution is a decent way of making `Adapter.getOptions` available to the overriding compiler function. One possible approach could be to pass `Adapter` as the `this` of the compile call. But I'm leaving it up to the package author to decide on this design issue.
